### PR TITLE
💚📦️ Install native package for docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,4 @@ RUN echo "http://dl-2.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositor
 # Install the latest Docker and docker-compose binaries
 RUN apk --update-cache --no-cache \
 	--allow-untrusted add \
-    docker \
-    py3-pip py3-docopt py3-yaml py3-texttable py3-websocket-client py3-distro py3-dockerpty py3-jsonschema py3-dotenv py3-paramiko \
-    && pip install docker-compose
+    docker docker-compose


### PR DESCRIPTION
Fix broken autobuild because of using `pip` to install system-wide while no more allowed by [PEP 668](https://peps.python.org/pep-0668/) since pip 23.

Fixed build: https://hub.docker.com/repository/registry-1.docker.io/zenika/alpine-jenkins-with-docker/builds/09b9581a-cc70-4eda-a73c-b51045e9fdbd ==> `zenika/alpine-jenkins-with-docker:fix-autobuild`